### PR TITLE
[feat] Sort SQL result tuples for fair comparison during evaluation #159

### DIFF
--- a/bird/llm/src/evaluation.py
+++ b/bird/llm/src/evaluation.py
@@ -13,6 +13,8 @@ def load_json(dir):
 def result_callback(result):
     exec_result.append(result)
 
+def sort_tuple(t):
+    return tuple(sorted(t, key=lambda x: str(x)))
 
 def execute_sql(predicted_sql,ground_truth, db_path):
     conn = sqlite3.connect(db_path)
@@ -22,6 +24,11 @@ def execute_sql(predicted_sql,ground_truth, db_path):
     predicted_res = cursor.fetchall()
     cursor.execute(ground_truth)
     ground_truth_res = cursor.fetchall()
+
+    # sort the results to allow fair comparison
+    predicted_res = [sort_tuple(t) for t in predicted_res]
+    ground_truth_res = [sort_tuple(t) for t in ground_truth_res]
+
     res = 0
     if set(predicted_res) == set(ground_truth_res):
         res = 1

--- a/bird/llm/src/evaluation.py
+++ b/bird/llm/src/evaluation.py
@@ -34,8 +34,6 @@ def execute_sql(predicted_sql,ground_truth, db_path):
         res = 1
     return res
 
-
-
 def execute_model(predicted_sql,ground_truth, db_place, idx, meta_time_out):
     try:
         res = func_timeout(meta_time_out, execute_sql,

--- a/bird/llm/src/evaluation_ves.py
+++ b/bird/llm/src/evaluation_ves.py
@@ -33,6 +33,9 @@ def execute_sql(sql, db_path):
     exec_time = time.time() - start_time
     return exec_time
 
+def sort_tuple(t):
+    return tuple(sorted(t, key=lambda x: str(x)))
+
 def iterated_execute_sql(predicted_sql,ground_truth,db_path,iterate_num):
     conn = sqlite3.connect(db_path)
     diff_list = []
@@ -41,6 +44,11 @@ def iterated_execute_sql(predicted_sql,ground_truth,db_path,iterate_num):
     predicted_res = cursor.fetchall()
     cursor.execute(ground_truth)
     ground_truth_res = cursor.fetchall()
+
+    # sort the results to allow fair comparison
+    predicted_res = [sort_tuple(t) for t in predicted_res]
+    ground_truth_res = [sort_tuple(t) for t in ground_truth_res]
+
     time_ratio = 0
     if set(predicted_res) == set(ground_truth_res):
         for i in range(iterate_num):


### PR DESCRIPTION
## Description
This feature was created to provide a better comparison when evaluating the Bird dataset. With the use of generative models for SQL generation, the SQL clauses in the `SELECT` statement are not always in the same order (see issue #159)

### Example
Ground Truth: `SELECT price, user FROM <table>`
Prediction: `SELECT user, price FROM <table>`

In the evaluation of the Bird dataset, this case is not taken into account. This improvement integrates a sorting mechanism for the tuples resulting from the SQL query execution to ensure consistent evaluation.

## Changes:
- Added sorting of tuples in the SQL query results for accurate comparison.
- Updated evaluation logic to handle the sorted clauses.
