### PR TITLE
feat: Add Forge as LLM provider

### DIFF
--- a/EPO/Sotopia/sotopia/generation_utils/generate.py
+++ b/EPO/Sotopia/sotopia/generation_utils/generate.py
@@ -508,6 +508,24 @@ def obtain_chain(
         )
         chain = chat_prompt_template | chat_openai
         return chain
+    elif model_name.startswith("forge"):
+        model_name = "/".join(model_name.split("/")[1:])
+        human_message_prompt = HumanMessagePromptTemplate(
+            prompt=PromptTemplate(
+                template=template,
+                input_variables=input_variables,
+            )
+        )
+        chat_prompt_template = ChatPromptTemplate.from_messages([human_message_prompt])
+        chat_openai = ChatOpenAI(
+            model_name=model_name,
+            temperature=temperature,
+            max_retries=max_retries,
+            openai_api_base=os.environ.get("FORGE_API_BASE", "https://api.forge.tensorblock.co/v1"),
+            openai_api_key=os.environ.get("FORGE_API_KEY"),
+        )
+        chain = chat_prompt_template | chat_openai
+        return chain
     elif model_name.startswith("groq"):
         model_name = "/".join(model_name.split("/")[1:])
         human_message_prompt = HumanMessagePromptTemplate(
@@ -1075,4 +1093,3 @@ async def agenerate_strategy(strategy_model: str, agent: str, history: str) -> s
     )
 
     
-


### PR DESCRIPTION
## Summary

Adds a `forge/` model routing branch in the `obtain_chain` function, following the same pattern as the existing `together_ai/` and `groq/` providers.

## Changes

- `EPO/Sotopia/sotopia/generation_utils/generate.py`: Added `elif model_name.startswith("forge"):` branch in `obtain_chain()` — strips the `forge/` prefix, reads `FORGE_API_KEY` and `FORGE_API_BASE` from environment, and passes them to `ChatOpenAI`. Follows the exact same structure as the `together_ai` and `groq` branches.

## Usage

```bash
export FORGE_API_KEY=your-forge-api-key
# Optional — defaults to https://api.forge.tensorblock.co/v1
export FORGE_API_BASE=https://api.forge.tensorblock.co/v1
```

Then use the `forge/` prefix with any model name:

```
model_name = "forge/openai/gpt-4o-mini"
```

The `forge/` prefix is stripped before sending to the API (e.g. `forge/openai/gpt-4o-mini` → `openai/gpt-4o-mini`).

I work at TensorBlock and will help maintain this integration.

---

## About Forge

[Forge](https://github.com/TensorBlock/Forge) is an open-source middleware that provides a unified API for 77+ AI providers (OpenAI, Anthropic, Google, DeepSeek, Together AI, Groq, etc.). It uses an OpenAI-compatible API format.

## References

- [Forge GitHub](https://github.com/TensorBlock/Forge)
- [Forge Documentation](https://www.tensorblock.co/api-docs/overview)